### PR TITLE
Adjust Python version and pip dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A 3DS/New 3DS Rom Decryptor and Encrypter
 ### If anyone wants to improve on the code, feel free to do so.
 
 ## Prerequisites
-* Python 3.11+
+* Python 3.10.12+
 * pip
-* pycryptodome
+* pycryptodomex
 
 ## Installation
-After you've installed the latest version of Python 2, run `pip install pycryptodome` in command prompt.
+After you've installed the latest version of Python, run `pip install pycryptodomex` in command prompt.
 
 ## Usage
 python {b3DSEncrypt.py|b3DSDecrypt.py} "File location of rom" eg. '~/dox/games/emulator/nintendo/3ds/3DS0033 - The Legend of Zelda Ocarina of Time 3D (U).3ds'


### PR DESCRIPTION
Adjusted Python version on README.md since it works well on 3.10.12, although I haven't checked the absolute minimum version it's required to run. Probably 3.6, mentioned in pycryptodome documentation.

Also, it states the following:
https://github.com/Legrandin/pycryptodome/blob/66fdb2c47a610f2acc45c0f18290d45c9255ed35/README.rst#L18-L40
```md
The installation procedure depends on the package you want the library to be in.
PyCryptodome can be used as:

#. **an almost drop-in replacement for the old PyCrypto library**.
   You install it with::

       pip install pycryptodome

   In this case, all modules are installed under the ``Crypto`` package.

   One must avoid having both PyCrypto and PyCryptodome installed
   at the same time, as they will interfere with each other.

   This option is therefore recommended only when you are sure that
   the whole application is deployed in a ``virtualenv``.

#. **a library independent of the old PyCrypto**.
   You install it with::

       pip install pycryptodomex

   In this case, all modules are installed under the ``Cryptodome`` package.
   PyCrypto and PyCryptodome can coexist.
```

And since both [b3DSDecrypt.py](https://github.com/DemonKingSwarn/b3DS/blob/master/b3DSDecrypt.py) and [b3DSEncrypt.py](https://github.com/DemonKingSwarn/b3DS/blob/master/b3DSEncrypt.py) import from `Cryptodome`, it's more appropriate to reference `pycryptodomex` instead of `pycryptodome` in the documentation.


